### PR TITLE
Extend edit command to support new categories

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -189,7 +189,8 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, salary, dateOfBirth, maritalStatus,
+                    occupation, dependents, tags);
         }
 
         public void setName(Name name) {
@@ -299,6 +300,9 @@ public class EditCommand extends Command {
                     && Objects.equals(address, otherEditPersonDescriptor.address)
                     && Objects.equals(salary, otherEditPersonDescriptor.salary)
                     && Objects.equals(dateOfBirth, otherEditPersonDescriptor.dateOfBirth)
+                    && Objects.equals(maritalStatus, otherEditPersonDescriptor.maritalStatus)
+                    && Objects.equals(occupation, otherEditPersonDescriptor.occupation)
+                    && Objects.equals(dependents, otherEditPersonDescriptor.dependents)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -3,9 +3,14 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE_OF_BIRTH;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEPENDENTS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MARITAL_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_OCCUPATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SALARY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -32,7 +37,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_SALARY,
+                        PREFIX_DATE_OF_BIRTH, PREFIX_MARITAL_STATUS, PREFIX_DEPENDENTS, PREFIX_OCCUPATION, PREFIX_TAG);
 
         Index index;
 
@@ -57,6 +63,26 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_SALARY).isPresent()) {
+            editPersonDescriptor.setSalary(ParserUtil.parseSalary(argMultimap.getValue(PREFIX_SALARY).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DATE_OF_BIRTH).isPresent()) {
+            editPersonDescriptor.setDateOfBirth(
+                    ParserUtil.parseDateOfBirth(argMultimap.getValue(PREFIX_DATE_OF_BIRTH).get()));
+        }
+        if (argMultimap.getValue(PREFIX_MARITAL_STATUS).isPresent()) {
+            editPersonDescriptor.setMaritalStatus(
+                    ParserUtil.parseMaritalStatus(argMultimap.getValue(PREFIX_MARITAL_STATUS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DEPENDENTS).isPresent()) {
+            editPersonDescriptor.setDependents(
+                    ParserUtil.parseDependents(
+                            Integer.parseInt(argMultimap.getValue(CliSyntax.PREFIX_DEPENDENTS).get())));
+        }
+        if (argMultimap.getValue(PREFIX_OCCUPATION).isPresent()) {
+            editPersonDescriptor.setOccupation(
+                    ParserUtil.parseOccupation(argMultimap.getValue(PREFIX_OCCUPATION).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/seedu/address/model/person/Dependents.java
+++ b/src/main/java/seedu/address/model/person/Dependents.java
@@ -36,6 +36,11 @@ public class Dependents {
     }
 
     @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/main/java/seedu/address/model/person/Salary.java
+++ b/src/main/java/seedu/address/model/person/Salary.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.text.DecimalFormat;
+
 /**
  * Represents a Person's salary in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidSalary(String)}
@@ -11,11 +13,13 @@ public class Salary {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Salaries can take any non-negative values, "
-            + "and it should not be blank";
+                    + "should not be blank, "
+                    + "and should have up to 2 decimal places.";
 
     /*
      * For a salary to be valid, it must be non-negative.
      * It can be an integer (e.g. "100") or a decimal with up to 2 decimal places (e.g. "100.10").
+     * Users can optionally include commas as separators for every 3 digits (e.g. "1,000" or "10,000.99").
      * Leading and/or trailing whitespaces are not allowed.
      */
     public static final String VALIDATION_REGEX = "\\d+(\\.\\d{1,2})?";
@@ -24,25 +28,39 @@ public class Salary {
 
     /**
      * Constructs a {@code Salary}.
+     * Stores the salary without commas to preserve formatting.
      *
      * @param salary A valid salary.
      */
     public Salary(String salary) {
         requireNonNull(salary);
-        checkArgument(isValidSalary(salary), MESSAGE_CONSTRAINTS);
-        value = salary;
+        String sanitizedSalary = salary.replace(",", "");
+        checkArgument(isValidSalary(sanitizedSalary), MESSAGE_CONSTRAINTS);
+        value = sanitizedSalary;
     }
 
     /**
      * Returns true if a given string is a valid salary.
      */
     public static boolean isValidSalary(String test) {
-        return test.matches(VALIDATION_REGEX);
+        String sanitizedSalary = test.replace(",", "");
+        return sanitizedSalary.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Formats the salary with a '$' sign in front and commas separating thousands.
+     * If the salary has decimal places, it will be formatted to two decimal places.
+     * @return A formatted string representation of the salary.
+     */
     @Override
     public String toString() {
-        return value;
+        try {
+            double amount = Double.parseDouble(this.value);
+            DecimalFormat formatter = new DecimalFormat("$#,##0.00");
+            return formatter.format(amount);
+        } catch (NumberFormatException e) {
+            return value;
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -62,7 +62,7 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
-        salary.setText(person.getSalary().value);
+        salary.setText(person.getSalary().toString());
         dateOfBirth.setText(person.getDateOfBirth().value);
         maritalStatus.setText(person.getMaritalStatus().value);
         dependents.setText(String.valueOf(person.getDependents().value));


### PR DESCRIPTION
Closes #68 

The edit command only supports editing a small subset of a person's details (name, phone, email, address).

Our target audience (financial advisors) would want more critical attributes of each client.

Let's,
* expand EditCommandParser to recognise prefixes for salary, date of birth, marital status, dependents, occupation
* update the EditCommand logic to apply these changes to a Person
* enhance the UI to correctly display these newly editable fields, including formatted currency for salary.

Tests for this PR and the previous PR regarding add commands will be done in a separate PR.