### PR TITLE
Update sort command to handle descending

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -16,19 +16,22 @@ public class SortCommand extends Command {
 
     public static final String COMMAND_WORD = "sort";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Sorts all persons by name in alphabetical order.\n"
-            + "Parameters: name or phone or email or address or salary\n"
-            + "or dateofbirth or maritalstatus or occupation or dependent\n"
-            + "Example: " + COMMAND_WORD + " name";
-    public static final String MESSAGE_SUCCESS = "Sorted all persons in alphabetical order by ";
+            + ": Sorts all persons by the specific field.\n"
+            + "Parameters: FIELD [DIRECTION]"
+            + "FIELD: name, phone, email, address, salary, dateofbirth, maritalstatus, occupation, dependent\n"
+            + "DIRECTION: ascending, descending\n"
+            + "Example: " + COMMAND_WORD + " name descending";
+    public static final String MESSAGE_SUCCESS = "Sorted all persons by ";
 
     private final SortField sortField;
+    private final SortDirection sortDirection;
 
     /**
      * @param sortField of the selected sort criteria
      */
-    public SortCommand(SortField sortField) {
+    public SortCommand(SortField sortField, SortDirection sortDirection) {
         this.sortField = sortField;
+        this.sortDirection = sortDirection;
     }
 
 
@@ -36,10 +39,12 @@ public class SortCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        Comparator<Person> nameComparator = nameComparator(sortField);
+        Comparator<Person> nameComparator = createComparator(sortField, sortDirection);
         model.sortPersonList(nameComparator);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS + sortField);
+        String directionText = sortDirection.toString().toLowerCase();
+        String message = MESSAGE_SUCCESS + sortField + " in " + directionText + " order";
+        return new CommandResult(message);
     }
 
     /**
@@ -50,36 +55,49 @@ public class SortCommand extends Command {
      * @return comparator that compares two persons based on the provided field
      * @throws AssertionError if an invalid field is provided
      **/
-    private static Comparator<Person> nameComparator(SortField sortField) {
+    private static Comparator<Person> createComparator(SortField sortField, SortDirection sortDirection) {
+        Comparator<Person> baseComparator;
+
         switch (sortField) {
         case NAME:
-            return (person1, person2) ->
+            baseComparator = (person1, person2) ->
                     person1.getName().fullName.compareToIgnoreCase(person2.getName().fullName);
+            break;
         case PHONE:
-            return (person1, person2) ->
+            baseComparator = (person1, person2) ->
                     person1.getPhone().value.compareToIgnoreCase(person2.getPhone().value);
+            break;
         case EMAIL:
-            return (person1, person2) ->
+            baseComparator = (person1, person2) ->
                     person1.getEmail().value.compareToIgnoreCase(person2.getEmail().value);
+            break;
         case ADDRESS:
-            return (person1, person2) ->
+            baseComparator = (person1, person2) ->
                     person1.getAddress().value.compareToIgnoreCase(person2.getAddress().value);
+            break;
         case SALARY:
-            return Comparator.comparingDouble(person -> Double.parseDouble(person.getSalary().value));
+            baseComparator = Comparator.comparingDouble(person -> Double.parseDouble(person.getSalary().value));
+            break;
         case DATEOFBIRTH:
-            return (person1, person2) ->
+            baseComparator = (person1, person2) ->
                     person1.getDateOfBirth().value.compareToIgnoreCase(person2.getDateOfBirth().value);
+            break;
         case MARITALSTATUS:
-            return (person1, person2) ->
+            baseComparator = (person1, person2) ->
                     person1.getMaritalStatus().value.compareToIgnoreCase(person2.getMaritalStatus().value);
+            break;
         case OCCUPATION:
-            return (person1, person2) ->
+            baseComparator = (person1, person2) ->
                     person1.getOccupation().value.compareToIgnoreCase(person2.getOccupation().value);
+            break;
         case DEPENDENT:
-            return Comparator.comparingInt(person -> person.getDependents().value);
+            baseComparator = Comparator.comparingInt(person -> person.getDependents().value);
+            break;
         default:
             throw new AssertionError("Invalid sort field" + sortField);
         }
+
+        return sortDirection == SortDirection.DESCENDING ? baseComparator.reversed() : baseComparator;
     }
 
     @Override
@@ -103,10 +121,18 @@ public class SortCommand extends Command {
         NAME, PHONE, EMAIL, ADDRESS, SALARY, DATEOFBIRTH, MARITALSTATUS, OCCUPATION, DEPENDENT
     }
 
+    /**
+     * Represents the available directions to sort by
+     **/
+    public enum SortDirection {
+        ASCENDING, DESCENDING
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("sortField", sortField)
+                .add("sortDirection", sortDirection)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.SortCommand.SortDirection;
 import seedu.address.logic.commands.SortCommand.SortField;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -25,30 +26,58 @@ public class SortCommandParser implements Parser<SortCommand> {
         }
 
         String[] argumentsArray = trimmedArguments.split("\\s+");
-        String sortType = argumentsArray[0];
+        String sortType = argumentsArray[0].toLowerCase();
 
-        switch(sortType.toLowerCase()) {
+        SortDirection direction = SortDirection.ASCENDING;
+
+        if (argumentsArray.length > 1) {
+            String directionOfSort = argumentsArray[1].toLowerCase();
+            switch(directionOfSort) {
+            case "ascending":
+                direction = SortDirection.ASCENDING;
+                break;
+            case "descending":
+                direction = SortDirection.DESCENDING;
+                break;
+            default:
+                break;
+            }
+        }
+
+        SortField field;
+        switch(sortType) {
         case "name":
-            return new SortCommand(SortField.NAME);
+            field = SortField.NAME;
+            break;
         case "phone":
-            return new SortCommand(SortField.PHONE);
+            field = SortField.PHONE;
+            break;
         case "email":
-            return new SortCommand(SortField.EMAIL);
+            field = SortField.EMAIL;
+            break;
         case "address":
-            return new SortCommand(SortField.ADDRESS);
+            field = SortField.ADDRESS;
+            break;
         case "salary":
-            return new SortCommand(SortField.SALARY);
+            field = SortField.SALARY;
+            break;
         case "dateofbirth":
-            return new SortCommand(SortField.DATEOFBIRTH);
+            field = SortField.DATEOFBIRTH;
+            break;
         case "maritalstatus":
-            return new SortCommand(SortField.MARITALSTATUS);
+            field = SortField.MARITALSTATUS;
+            break;
         case "occupation":
-            return new SortCommand(SortField.OCCUPATION);
+            field = SortField.OCCUPATION;
+            break;
         case "dependent":
-            return new SortCommand(SortField.DEPENDENT);
+            field = SortField.DEPENDENT;
+            break;
         default:
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
         }
+
+        return new SortCommand(field, direction);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -5,14 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.SortCommand.SortDirection;
 import seedu.address.logic.commands.SortCommand.SortField;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -27,84 +30,165 @@ public class SortCommandTest {
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_sortByName_success() {
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.NAME;
-        SortCommand command = new SortCommand(SortField.NAME);
-        new SortCommand(SortField.NAME).execute(expectedModel);
+    public void execute_sortByNameAscending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.NAME + " in ascending order";
+        SortCommand command = new SortCommand(SortField.NAME, SortDirection.ASCENDING);
+        new SortCommand(SortField.NAME, SortDirection.ASCENDING).execute(expectedModel);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(ALICE, model.getFilteredPersonList().get(0));
     }
 
     @Test
-    public void execute_sortByPhone_success() {
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.PHONE;
-        SortCommand command = new SortCommand(SortField.PHONE);
-        new SortCommand(SortField.PHONE).execute(expectedModel);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(DANIEL, model.getFilteredPersonList().get(0));
-    }
-
-    @Test
-    public void execute_sortByEmail_success() {
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.EMAIL;
-        SortCommand command = new SortCommand(SortField.EMAIL);
-        new SortCommand(SortField.EMAIL).execute(expectedModel);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(ALICE, model.getFilteredPersonList().get(0));
-    }
-
-    @Test
-    public void execute_sortByAddress_success() {
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.ADDRESS;
-        SortCommand command = new SortCommand(SortField.ADDRESS);
-        new SortCommand(SortField.ADDRESS).execute(expectedModel);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(DANIEL, model.getFilteredPersonList().get(0));
-    }
-
-    @Test
-    public void execute_sortBySalary_success() {
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.SALARY;
-        SortCommand command = new SortCommand(SortField.SALARY);
-        new SortCommand(SortField.SALARY).execute(expectedModel);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(ALICE, model.getFilteredPersonList().get(0));
-    }
-
-    @Test
-    public void execute_sortByDateOfBirth_success() {
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.DATEOFBIRTH;
-        SortCommand command = new SortCommand(SortField.DATEOFBIRTH);
-        new SortCommand(SortField.DATEOFBIRTH).execute(expectedModel);
+    public void execute_sortByNameDescending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.NAME + " in descending order";
+        SortCommand command = new SortCommand(SortField.NAME, SortDirection.DESCENDING);
+        new SortCommand(SortField.NAME, SortDirection.DESCENDING).execute(expectedModel);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(GEORGE, model.getFilteredPersonList().get(0));
     }
 
     @Test
-    public void execute_sortByMaritalStatus_success() {
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.MARITALSTATUS;
-        SortCommand command = new SortCommand(SortField.MARITALSTATUS);
-        new SortCommand(SortField.MARITALSTATUS).execute(expectedModel);
+    public void execute_sortByPhoneAscending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.PHONE + " in ascending order";
+        SortCommand command = new SortCommand(SortField.PHONE, SortDirection.ASCENDING);
+        new SortCommand(SortField.PHONE, SortDirection.ASCENDING).execute(expectedModel);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(DANIEL, model.getFilteredPersonList().get(0));
     }
 
     @Test
-    public void execute_sortByOccupation_success() {
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.OCCUPATION;
-        SortCommand command = new SortCommand(SortField.OCCUPATION);
-        new SortCommand(SortField.OCCUPATION).execute(expectedModel);
+    public void execute_sortByPhoneDescending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.PHONE + " in descending order";
+        SortCommand command = new SortCommand(SortField.PHONE, SortDirection.DESCENDING);
+        new SortCommand(SortField.PHONE, SortDirection.DESCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(BENSON, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByEmailAscending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.EMAIL + " in ascending order";
+        SortCommand command = new SortCommand(SortField.EMAIL, SortDirection.ASCENDING);
+        new SortCommand(SortField.EMAIL, SortDirection.ASCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(ALICE, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByEmailDescending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.EMAIL + " in descending order";
+        SortCommand command = new SortCommand(SortField.EMAIL, SortDirection.DESCENDING);
+        new SortCommand(SortField.EMAIL, SortDirection.DESCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(ELLE, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByAddressAscending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.ADDRESS + " in ascending order";
+        SortCommand command = new SortCommand(SortField.ADDRESS, SortDirection.ASCENDING);
+        new SortCommand(SortField.ADDRESS, SortDirection.ASCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(DANIEL, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByAddressDescending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.ADDRESS + " in descending order";
+        SortCommand command = new SortCommand(SortField.ADDRESS, SortDirection.DESCENDING);
+        new SortCommand(SortField.ADDRESS, SortDirection.DESCENDING).execute(expectedModel);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(CARL, model.getFilteredPersonList().get(0));
     }
 
     @Test
-    public void execute_sortByDependent_success() {
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.DEPENDENT;
-        SortCommand command = new SortCommand(SortField.DEPENDENT);
-        new SortCommand(SortField.DEPENDENT).execute(expectedModel);
+    public void execute_sortBySalaryAscending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.SALARY + " in ascending order";
+        SortCommand command = new SortCommand(SortField.SALARY, SortDirection.ASCENDING);
+        new SortCommand(SortField.SALARY, SortDirection.ASCENDING).execute(expectedModel);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(FIONA, model.getFilteredPersonList().get(model.getFilteredPersonList().size() - 1));
+        assertEquals(ALICE, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortBySalaryDescending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.SALARY + " in descending order";
+        SortCommand command = new SortCommand(SortField.SALARY, SortDirection.DESCENDING);
+        new SortCommand(SortField.SALARY, SortDirection.DESCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(GEORGE, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByDateOfBirthAscending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.DATEOFBIRTH + " in ascending order";
+        SortCommand command = new SortCommand(SortField.DATEOFBIRTH, SortDirection.ASCENDING);
+        new SortCommand(SortField.DATEOFBIRTH, SortDirection.ASCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(GEORGE, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByDateOfBirthDescending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.DATEOFBIRTH + " in descending order";
+        SortCommand command = new SortCommand(SortField.DATEOFBIRTH, SortDirection.DESCENDING);
+        new SortCommand(SortField.DATEOFBIRTH, SortDirection.DESCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(ALICE, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByMaritalStatusAscending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.MARITALSTATUS + " in ascending order";
+        SortCommand command = new SortCommand(SortField.MARITALSTATUS, SortDirection.ASCENDING);
+        new SortCommand(SortField.MARITALSTATUS, SortDirection.ASCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(DANIEL, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByMaritalStatusDescending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.MARITALSTATUS + " in descending order";
+        SortCommand command = new SortCommand(SortField.MARITALSTATUS, SortDirection.DESCENDING);
+        new SortCommand(SortField.MARITALSTATUS, SortDirection.DESCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(ALICE, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByOccupationAscending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.OCCUPATION + " in ascending order";
+        SortCommand command = new SortCommand(SortField.OCCUPATION, SortDirection.ASCENDING);
+        new SortCommand(SortField.OCCUPATION, SortDirection.ASCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(CARL, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByOccupationDescending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.OCCUPATION + " in descending order";
+        SortCommand command = new SortCommand(SortField.OCCUPATION, SortDirection.DESCENDING);
+        new SortCommand(SortField.OCCUPATION, SortDirection.DESCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(BENSON, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByDependentAscending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.DEPENDENT + " in ascending order";
+        SortCommand command = new SortCommand(SortField.DEPENDENT, SortDirection.ASCENDING);
+        new SortCommand(SortField.DEPENDENT, SortDirection.ASCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(ALICE, model.getFilteredPersonList().get(0));
+    }
+
+    @Test
+    public void execute_sortByDependentDescending_success() {
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.DEPENDENT + " in descending order";
+        SortCommand command = new SortCommand(SortField.DEPENDENT, SortDirection.DESCENDING);
+        new SortCommand(SortField.DEPENDENT, SortDirection.DESCENDING).execute(expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(FIONA, model.getFilteredPersonList().get(0));
     }
 
     @Test
@@ -112,8 +196,8 @@ public class SortCommandTest {
         Model emptyModel = new ModelManager();
         Model expectedEmptyModel = new ModelManager();
 
-        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.NAME;
-        SortCommand command = new SortCommand(SortField.NAME);
+        String expectedMessage = SortCommand.MESSAGE_SUCCESS + SortField.NAME + " in ascending order";
+        SortCommand command = new SortCommand(SortField.NAME, SortDirection.ASCENDING);
 
         assertCommandSuccess(command, emptyModel, expectedMessage, expectedEmptyModel);
         assertEquals(0, emptyModel.getFilteredPersonList().size());
@@ -121,14 +205,14 @@ public class SortCommandTest {
 
     @Test
     public void equals() {
-        SortCommand sortNameCommand = new SortCommand(SortField.NAME);
-        SortCommand sortPhoneCommand = new SortCommand(SortField.PHONE);
+        SortCommand sortNameCommand = new SortCommand(SortField.NAME, SortDirection.ASCENDING);
+        SortCommand sortPhoneCommand = new SortCommand(SortField.PHONE, SortDirection.ASCENDING);
 
         // same object -> returns true
         assertTrue(sortNameCommand.equals(sortNameCommand));
 
         // same values -> returns true
-        SortCommand commandWithSameSortFieldValues = new SortCommand(SortField.NAME);
+        SortCommand commandWithSameSortFieldValues = new SortCommand(SortField.NAME, SortDirection.ASCENDING);
         assertTrue(sortNameCommand.equals(commandWithSameSortFieldValues));
 
         // different types -> returns false
@@ -143,8 +227,9 @@ public class SortCommandTest {
 
     @Test
     public void toStringMethod() {
-        SortCommand sortCommand = new SortCommand(SortField.NAME);
-        String expected = SortCommand.class.getCanonicalName() + "{sortField=" + SortField.NAME + "}";
+        SortCommand sortCommand = new SortCommand(SortField.NAME, SortDirection.ASCENDING);
+        String expected = SortCommand.class.getCanonicalName() + "{sortField=" + SortField.NAME
+                + ", sortDirection=" + SortDirection.ASCENDING + "}";
         assertEquals(expected, sortCommand.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -114,6 +114,8 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " phone") instanceof SortCommand);
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " email") instanceof SortCommand);
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " address") instanceof SortCommand);
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " name ascending") instanceof SortCommand);
+        assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " name descending") instanceof SortCommand);
         assertTrue(parser.parseCommand(SortCommand.COMMAND_WORD + " name 3") instanceof SortCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.commands.SortCommand.SortDirection;
 import seedu.address.logic.commands.SortCommand.SortField;
 
 public class SortCommandParserTest {
@@ -15,42 +16,74 @@ public class SortCommandParserTest {
     @Test
     public void parse_validArgs_returnsSortCommand() {
         // Test all valid fields
-        assertParseSuccess(parser, "name", new SortCommand(SortField.NAME));
-        assertParseSuccess(parser, "phone", new SortCommand(SortField.PHONE));
-        assertParseSuccess(parser, "email", new SortCommand(SortField.EMAIL));
-        assertParseSuccess(parser, "address", new SortCommand(SortField.ADDRESS));
-        assertParseSuccess(parser, "salary", new SortCommand(SortField.SALARY));
-        assertParseSuccess(parser, "dateofbirth", new SortCommand(SortField.DATEOFBIRTH));
-        assertParseSuccess(parser, "maritalstatus", new SortCommand(SortField.MARITALSTATUS));
-        assertParseSuccess(parser, "occupation", new SortCommand(SortField.OCCUPATION));
-        assertParseSuccess(parser, "dependent", new SortCommand(SortField.DEPENDENT));
+        assertParseSuccess(parser, "name", new SortCommand(SortField.NAME, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "phone", new SortCommand(SortField.PHONE, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "email", new SortCommand(SortField.EMAIL, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "address", new SortCommand(SortField.ADDRESS, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "salary",
+                new SortCommand(SortField.SALARY, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "dateofbirth",
+                new SortCommand(SortField.DATEOFBIRTH, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "maritalstatus",
+                new SortCommand(SortField.MARITALSTATUS, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "occupation",
+                new SortCommand(SortField.OCCUPATION, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "dependent", new SortCommand(SortField.DEPENDENT, SortDirection.ASCENDING));
+
+        // Test ascending
+        assertParseSuccess(parser, "name ascending", new SortCommand(SortField.NAME, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "phone ascending",
+                new SortCommand(SortField.PHONE, SortDirection.ASCENDING));
+
+        // Test descending
+        assertParseSuccess(parser, "name descending",
+                new SortCommand(SortField.NAME, SortDirection.DESCENDING));
+        assertParseSuccess(parser, "phone descending",
+                new SortCommand(SortField.PHONE, SortDirection.DESCENDING));
 
         // Test case insensitive
-        assertParseSuccess(parser, "NaMe", new SortCommand(SortField.NAME));
-        assertParseSuccess(parser, "depeNDent", new SortCommand(SortField.DEPENDENT));
+        assertParseSuccess(parser, "NaMe", new SortCommand(SortField.NAME, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "depeNDent ascending",
+                new SortCommand(SortField.DEPENDENT, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "oCCupatIon descending",
+                new SortCommand(SortField.OCCUPATION, SortDirection.DESCENDING));
 
         // Test ignore extra arguments
-        assertParseSuccess(parser, "name 222", new SortCommand(SortField.NAME));
-        assertParseSuccess(parser, "address 234", new SortCommand(SortField.ADDRESS));
+        assertParseSuccess(parser, "name 222", new SortCommand(SortField.NAME, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "address ascending 234",
+                new SortCommand(SortField.ADDRESS, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "address descending 234aaa",
+                new SortCommand(SortField.ADDRESS, SortDirection.DESCENDING));
 
         // Test ignore extra space
-        assertParseSuccess(parser, "   name  ", new SortCommand(SortField.NAME));
-        assertParseSuccess(parser, "   dependent  ", new SortCommand(SortField.DEPENDENT));
+        assertParseSuccess(parser, "   name  ", new SortCommand(SortField.NAME, SortDirection.ASCENDING));
+        assertParseSuccess(parser, "   dependent  ascending",
+                new SortCommand(SortField.DEPENDENT, SortDirection.ASCENDING));
+
+        // Test invalid direction text
+        assertParseSuccess(parser, "dependent invalidDirection",
+                new SortCommand(SortField.DEPENDENT, SortDirection.ASCENDING));
     }
 
     @Test
     public void parse_emptyArg_throwsParseException() {
         //Test empty strings
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidArg_throwsParseException() {
         //Test invalid fields
-        assertParseFailure(parser, "111", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "named", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "addres", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "phon", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "111",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "named",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "addres",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "phon",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
closes #101 

The sort command need to be able to sort by descending order.

Lets,

1. Update sortCommand and sortCommandParser to take in specifics (ascending and descending).
2. Update test cases in SortCommandTest, SortCommandParserTest and AddressBookParserTest.