### PR TITLE
Fix bug where app wipes addressbook.json when closed and load again

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -82,23 +82,6 @@ public class MainApp extends Application {
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
         logger.info("Using data file : " + storage.getAddressBookFilePath());
 
-        Optional<ReadOnlyAddressBook> addressBookOptional;
-        ReadOnlyAddressBook initialData;
-        try {
-            addressBookOptional = storage.readAddressBook();
-            if (!addressBookOptional.isPresent()) {
-                logger.info("Creating a new data file " + storage.getAddressBookFilePath()
-                        + " populated with a sample AddressBook.");
-            }
-            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
-        } catch (DataLoadingException e) {
-            logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
-                    + " Will be starting with an empty AddressBook.");
-            initialData = new AddressBook();
-        }
-
-        logger.info("Using insurance catalog file: " + storage.getInsuranceCatalogFilePath());
-
         Optional<ReadOnlyInsuranceCatalog> insuranceCatalogOptional;
         ReadOnlyInsuranceCatalog initialInsuranceCatalog;
         try {
@@ -116,6 +99,23 @@ public class MainApp extends Application {
                     + " Will be starting with an empty InsuranceCatalog.");
             initialInsuranceCatalog = new InsuranceCatalog();
         }
+
+        Optional<ReadOnlyAddressBook> addressBookOptional;
+        ReadOnlyAddressBook initialData;
+        try {
+            addressBookOptional = storage.readAddressBook();
+            if (!addressBookOptional.isPresent()) {
+                logger.info("Creating a new data file " + storage.getAddressBookFilePath()
+                        + " populated with a sample AddressBook.");
+            }
+            initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
+        } catch (DataLoadingException e) {
+            logger.warning("Data file at " + storage.getAddressBookFilePath() + " could not be loaded."
+                    + " Will be starting with an empty AddressBook.");
+            initialData = new AddressBook();
+        }
+
+        logger.info("Using insurance catalog file: " + storage.getInsuranceCatalogFilePath());
 
         return new ModelManager(initialData, initialInsuranceCatalog, userPrefs);
     }


### PR DESCRIPTION
Closes #141.

Currently, the app will wipe the data in addressbook.json when it is closed and ran again. The reason is because the app attempts to load the Persons data first, checking if the InsurancePackage for each Person is valid. However, the list of approved insurance packages in InsuranceCatalog has not been created yet, thus all insurance packages are considered invalid.

This PR aims to resolve the above problem by loading the InsuranceCatalog first, before loading the AddressBook.