### PR TITLE
Make tags case insensitive

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -45,12 +45,12 @@ public class Tag {
         }
 
         Tag otherTag = (Tag) other;
-        return tagName.equals(otherTag.tagName);
+        return tagName.equalsIgnoreCase(otherTag.tagName);
     }
 
     @Override
     public int hashCode() {
-        return tagName.hashCode();
+        return tagName.toLowerCase().hashCode();
     }
 
     /**


### PR DESCRIPTION
Closes #324

Now duplicate tags are case insensitive, 

e.g. For the command edit 1 t/my tag t/My TaG, they are recognised to be the same tag, and only "my tag" will be added to the contact.