### PR TITLE
Shorten add/edit/delete person success messages

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,11 +1,14 @@
 package seedu.address.logic;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.insurance.InsurancePackage;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 
 /**
@@ -37,8 +40,45 @@ public class Messages {
         return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
     }
 
+    private static void appendIfPresent(StringBuilder builder, String label, Optional<?> optField) {
+        optField.ifPresent(o -> builder.append("; ").append(label).append(": ").append(o));
+    }
+
     /**
-     * Formats the {@code person} for display to the user.
+     * Formats the success message for an edited person after a successful edit command, showing only changed fields.
+     */
+    public static String formatEditedPerson(Name name, EditCommand.EditPersonDescriptor descriptor) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(name);
+
+        appendIfPresent(builder, "Phone", descriptor.getPhone());
+        appendIfPresent(builder, "Email", descriptor.getEmail());
+        appendIfPresent(builder, "Address", descriptor.getAddress());
+        appendIfPresent(builder, "Salary", descriptor.getSalary());
+        appendIfPresent(builder, "Date of Birth", descriptor.getDateOfBirth());
+        appendIfPresent(builder, "Marital Status", descriptor.getMaritalStatus());
+        appendIfPresent(builder, "Occupation", descriptor.getOccupation());
+        appendIfPresent(builder, "Dependents", descriptor.getDependents());
+        appendIfPresent(builder, "Insurance Package", descriptor.getInsurancePackage());
+
+        descriptor.getTags().ifPresent(tags -> {
+            if (!tags.isEmpty()) {
+                builder.append("; Tags: ");
+                tags.forEach(builder::append);
+            }
+        });
+
+        return builder.toString();
+    }
+
+    private static void appendIfSpecified(StringBuilder builder, String label, Object field) {
+        if (!field.toString().equals("Unspecified")) {
+            builder.append(label).append(field);
+        }
+    }
+
+    /**
+     * Formats the {@code person} for display to the user after a successful add or delete command.
      */
     public static String format(Person person) {
         final StringBuilder builder = new StringBuilder();
@@ -49,20 +89,18 @@ public class Messages {
                 .append(person.getEmail())
                 .append("; Address: ")
                 .append(person.getAddress())
-                .append("; Salary: ")
-                .append(person.getSalary())
-                .append("; Date of Birth: ")
-                .append(person.getDateOfBirth())
-                .append("; Marital Status: ")
-                .append(person.getMaritalStatus())
-                .append("; Dependents: ")
-                .append(person.getDependents())
-                .append("; Occupation: ")
-                .append(person.getOccupation())
                 .append("; Insurance Package: ")
-                .append(person.getInsurancePackage())
-                .append("; Tags: ");
-        person.getTags().forEach(builder::append);
+                .append(person.getInsurancePackage());
+        appendIfSpecified(builder, "; Salary: ", person.getSalary());
+        appendIfSpecified(builder, "; Date of Birth: ", person.getDateOfBirth());
+        appendIfSpecified(builder, "; Marital Status: ", person.getMaritalStatus());
+        appendIfSpecified(builder, "; Dependents: ", person.getDependents());
+        appendIfSpecified(builder, "; Occupation: ", person.getOccupation());
+
+        if (!person.getTags().isEmpty()) {
+            builder.append("; Tags: ");
+            person.getTags().forEach(tag -> builder.append(tag).append(" "));
+        }
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -99,7 +99,8 @@ public class EditCommand extends Command {
 
         updateModel(model, personToEdit, editedPerson);
 
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.formatEditedPerson(personToEdit.getName(), editPersonDescriptor)));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -42,7 +42,8 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.formatEditedPerson(model.getFilteredPersonList().get(0).getName(), descriptor));
 
         Model expectedModel =
                 new ModelManager(new AddressBook(model.getAddressBook()), model.getInsuranceCatalog(), new UserPrefs());
@@ -64,7 +65,8 @@ public class EditCommandTest {
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.formatEditedPerson(lastPerson.getName(), descriptor));
 
         Model expectedModel =
                 new ModelManager(new AddressBook(model.getAddressBook()), model.getInsuranceCatalog(), new UserPrefs());
@@ -78,7 +80,10 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        EditPersonDescriptor descriptor = new EditPersonDescriptor();
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.formatEditedPerson(editedPerson.getName(), descriptor));
 
         Model expectedModel =
                 new ModelManager(new AddressBook(model.getAddressBook()), model.getInsuranceCatalog(), new UserPrefs());
@@ -92,10 +97,12 @@ public class EditCommandTest {
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
-                new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS,
+                Messages.formatEditedPerson(personInFilteredList.getName(), descriptor));
 
         Model expectedModel =
                 new ModelManager(new AddressBook(model.getAddressBook()), model.getInsuranceCatalog(), new UserPrefs());


### PR DESCRIPTION
Closes #294, closes #321

Success message formatter for edit command has been refactored to only show fields that have been edited.
If a contact's name has been edited, the success message will show the previous name but the GUI will show the new name.

Additionally, for add/delete commands, their success messages will only show all fields that are not "Unspecified".